### PR TITLE
Use default pkg.json#files style

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "port"
   ],
   "files": [
-    "find-open-port.js"
+    "*.js",
+    "lib"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
This got messed up in https://github.com/testiumjs/find-open-port/pull/2. The file moved but the `package.json#files` entry wasn't updated.

Verified via:

```bash
> npm i ~/Projects/testium/find-open-port && node -p 'require("find-open-port")'
find-open-port@1.0.1 node_modules/find-open-port
└── bluebird@3.4.0
{ [Function: findPort]
  findPort: [Circular],
  default: [Circular],
  isAvailable: [Function: isAvailable] }
```